### PR TITLE
normrandvel

### DIFF
--- a/filters/normrandvel.c
+++ b/filters/normrandvel.c
@@ -3,7 +3,7 @@ MFD_FILTER(normrandvel)
 #ifdef MX_TTF
 
     mflt:normrandvel
-    TTF_DEFAULTDEF("MIDI Velocity Randomization")
+    TTF_DEFAULTDEF("MIDI Velocity Randomization (Normal)")
     , TTF_IPORT(0, "channel", "Channel", 0.0, 16.0, 0.0, \
     lv2:portProperty lv2:integer; lv2:scalePoint [ rdfs:label "Any" ; rdf:value 0.0 ])
     , TTF_IPORTFLOAT(1, "dev", "Velocity Standard Deviation", 0.0, 64.0, 8.0)


### PR DESCRIPTION
added a filter that randomizes velocity according to a normal distribution. This is more computationally intensive than randomvelocity, but should yield more natural results. The normal approximation is accomplished through a modified Marsaglia polar method, with a bound on the number of redraws allowed. There is approximately a %25 redraw rate, but it is limited to 3 tries per outcome. In event of failure the velocity is left unchanged.
