### PR TITLE
Update mididelay.c

### DIFF
--- a/filters/mididelay.c
+++ b/filters/mididelay.c
@@ -23,7 +23,7 @@ MFD_FILTER(mididelay)
 			rdfs:comment "delay length in base-unit")
 	, TTF_IPORT( 3, "delayRandom", "Randomize [Beats]", 0.0, 1.0,  0.0,
 			rdfs:comment "randomization factor")
-	; rdfs:comment "MIDI delay line. Delay all MIDI events by a given time which is give as BPM and beats. If the delay includes a random factor, this effect takes care of always keeping note on/off events sequential regardless of the randomization."
+	; rdfs:comment "MIDI delay line. Delay all MIDI events by a given time which is given as BPM and beats. If the delay includes a random factor, this effect takes care of always keeping note on/off events sequential regardless of the randomization."
 	.
 
 #elif defined MX_CODE


### PR DESCRIPTION
typo (if I'm correct).

It found it from the https://x42.github.io/midifilter.lv2/index.html webpage and if I did understand correctly what you said in another thread, this webpage is automagically build from (this part of) the source code.
 