### PR TITLE
added toggle mode to notetocc

### DIFF
--- a/filters/notetocc.c
+++ b/filters/notetocc.c
@@ -82,12 +82,12 @@ filter_midi_notetocc(MidiFilter* self,
 			break;
 		case 3: // toggle, param <- note,  value <- 0 or 127 
 			buf[1] = key;
-            if (mst == MIDI_NOTEOFF) {
-                buf[2] = 0;
-            } else {
-                buf[2] = 127;
-            }
-            //no break
+			if (mst == MIDI_NOTEOFF) {
+				buf[2] = 0;
+			} else {
+				buf[2] = 127;
+			}
+			//no break
 	}
 	if (mst == MIDI_NOTEON || (*(self->cfg[4])) <= 0 || mode == 3) {
 		forge_midimessage(self, tme, buf, 3);


### PR DESCRIPTION
I already did the work so I thought I'd do the PR. Feel free to reject or reformat as this same effect could be accomplished many ways using additional filters or settings on the midi note generator. It may still have some value. I wanted it when I was using the older note2cc on MOD that doesn't yet have the option to send CC value 0 on note-off.