### PR TITLE
Add velocity gamma filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ So far 29 MIDI event filters have been implemented:
 *   Sostenuto -- delay note-off messages, emulate a piano sostenuto pedal
 *   Velocity Range -- filter MIDI note events according to velocity
 *   Velocity Scale -- modify note velocity by constant factor and offset
+*   Velocity Gamma -- modify note velocity curve by a gamma exponent
 
 Install
 -------

--- a/filters/velocitygamma.c
+++ b/filters/velocitygamma.c
@@ -1,0 +1,71 @@
+MFD_FILTER(velocitygamma)
+
+#ifdef MX_TTF
+
+	mflt:velocitygamma
+	TTF_DEFAULTDEF("MIDI Velocity Gamma", "MIDI Vel. Gamma")
+	, TTF_IPORT(0, "channel", "Channel", 0, 16, 0,
+			PORTENUMZ("Any")
+			DOC_CHANF)
+	, TTF_IPORTFLOAT(1, "ongamma",  "Note-on Gamma",     0.0,   5.0,   1.0)
+	, TTF_IPORTFLOAT(2, "offgamma", "Note-off Gamma",    0.0,   5.0,   1.0)
+	; rdfs:comment "Change the velocity of note events with separate controls for Note-on and Note-off. "
+                   "Velocities are first normalized to the range 0..1, then the gamma is applied as an "
+                   "exponent, and then the result is scaled back onto the 0..127 range. "
+                   "Higher gamma values produce a 'softer' velocity curve, lower gamma values make "
+                   "the low end harder. Gamma = 0 effectively produces a constant velocity."
+	.
+
+#elif defined MX_CODE
+
+static void filter_init_velocitygamma(MidiFilter* self) { }
+
+static void
+filter_midi_velocitygamma(MidiFilter* self,
+		uint32_t tme,
+		const uint8_t* const buffer,
+		uint32_t size)
+{
+	const int chs = midi_limit_chn(floorf(*self->cfg[0]) -1);
+	const uint8_t chn = buffer[0] & 0x0f;
+	uint8_t mst = buffer[0] & 0xf0;
+
+	if (size != 3
+			|| !(mst == MIDI_NOTEON || mst == MIDI_NOTEOFF)
+			|| !(floorf(*self->cfg[0]) == 0 || chs == chn)
+		 )
+	{
+		forge_midimessage(self, tme, buffer, size);
+		return;
+	}
+
+	const uint8_t vel  = (buffer[2] & 0x7f);
+
+	if (mst == MIDI_NOTEON && vel == 0 ) {
+		mst = MIDI_NOTEOFF;
+	}
+
+	uint8_t buf[3];
+	buf[0] = buffer[0];
+	buf[1] = buffer[1];
+
+
+	switch(mst) {
+		case MIDI_NOTEON:
+			{
+				const float gamma = *(self->cfg[1]);
+				buf[2] = RAIL(rintf(powf((float)vel / 127.0f, gamma) * 127.0f), 1, 127);
+			}
+			break;
+		case MIDI_NOTEOFF:
+			{
+				const float gamma = *(self->cfg[2]);
+				buf[2] = RAIL(rintf(powf((float)vel / 127.0f, gamma) * 127.0f), 1, 127);
+			}
+			break;
+	}
+	forge_midimessage(self, tme, buf, size);
+}
+
+#endif
+

--- a/modgui/icon-velocitygamma.html
+++ b/modgui/icon-velocitygamma.html
@@ -1,0 +1,66 @@
+<div class="mod-pedal x42-midifilter{{{cns}}} x42-midi-velocitygamma">
+    <div mod-role="drag-handle" class="mod-drag-handle"></div>
+    <div class="x42-brand"><h1 title="Brought to you by x42.">x42</h1></div>
+    <div class="x42-plugin-name"><h1>MIDI Velocity Gamma</h1></div>
+
+    <div class="mod-light on" mod-role="bypass-light"></div>
+    <div class="mod-footswitch" mod-role="bypass"></div>
+
+    <div class="mod-control-group mod-enumerated-group bottom clearfix">
+        <span class="mod-knob-title">Midi Channel</span>
+        <div class="mod-enumerated" mod-role="input-control-port" mod-port-symbol="channel" mod-widget="custom-select">
+          <div mod-role="input-control-value" mod-port-symbol="channel" class="mod-enumerated-selected"></div>
+          <div class="mod-enumerated-list">
+            <div mod-role="enumeration-option" mod-port-value="0">Any</div>
+            <div mod-role="enumeration-option" mod-port-value="1">1</div>
+            <div mod-role="enumeration-option" mod-port-value="2">2</div>
+            <div mod-role="enumeration-option" mod-port-value="3">3</div>
+            <div mod-role="enumeration-option" mod-port-value="4">4</div>
+            <div mod-role="enumeration-option" mod-port-value="5">5</div>
+            <div mod-role="enumeration-option" mod-port-value="6">6</div>
+            <div mod-role="enumeration-option" mod-port-value="7">7</div>
+            <div mod-role="enumeration-option" mod-port-value="8">8</div>
+            <div mod-role="enumeration-option" mod-port-value="9">9</div>
+            <div mod-role="enumeration-option" mod-port-value="10">10</div>
+            <div mod-role="enumeration-option" mod-port-value="11">11</div>
+            <div mod-role="enumeration-option" mod-port-value="12">12</div>
+            <div mod-role="enumeration-option" mod-port-value="13">13</div>
+            <div mod-role="enumeration-option" mod-port-value="14">14</div>
+            <div mod-role="enumeration-option" mod-port-value="15">15</div>
+            <div mod-role="enumeration-option" mod-port-value="16">16</div>
+          </div>
+        </div>
+    </div>
+
+
+    <div class="mod-control-group top clearfix">
+        <div class="mod-knob">
+          <span class="mod-knob-title">Note-on Gamma</span>
+            <div class="mod-knob-n127-image" mod-role="input-control-port" mod-port-symbol="ongamma"></div>
+        </div>
+    </div>
+
+    <div class="mod-control-group top clearfix">
+        <div class="mod-knob">
+          <span class="mod-knob-title">Note-off Gamma</span>
+            <div class="mod-knob-n127-image" mod-role="input-control-port" mod-port-symbol="ongamma"></div>
+        </div>
+    </div>
+
+
+
+    <div class="mod-pedal-input">
+        {{#effect.ports.midi.input}}
+        <div class="mod-input mod-input-disconnected" title="{{name}}" mod-role="input-midi-port" mod-port-symbol="{{symbol}}">
+            <div class="mod-pedal-input-image"></div>
+        </div>
+        {{/effect.ports.midi.input}}
+    </div>
+    <div class="mod-pedal-output">
+        {{#effect.ports.midi.output}}
+        <div class="mod-output mod-output-disconnected" title="{{name}}" mod-role="output-midi-port" mod-port-symbol="{{symbol}}">
+            <div class="mod-pedal-output-image"></div>
+        </div>
+        {{/effect.ports.midi.output}}
+    </div>
+</div>

--- a/modgui/x42-style.css
+++ b/modgui/x42-style.css
@@ -450,6 +450,7 @@
 }
 
 .x42-midifilter{{{cns}}}.x42-midi-velocityscale .mod-light,
+.x42-midifilter{{{cns}}}.x42-midi-velocitygamma .mod-light,
 .x42-midifilter{{{cns}}}.x42-midi-strum .mod-light,
 .x42-midifilter{{{cns}}}.x42-midi-onechannelfilter .mod-light,
 .x42-midifilter{{{cns}}}.x42-midi-ntapdelay .mod-light,
@@ -556,6 +557,7 @@
 }
 
 .x42-midifilter{{{cns}}}.x42-midi-velocityscale .mod-footswitch,
+.x42-midifilter{{{cns}}}.x42-midi-velocitygamma .mod-footswitch,
 .x42-midifilter{{{cns}}}.x42-midi-strum .mod-footswitch,
 .x42-midifilter{{{cns}}}.x42-midi-midichord .mod-footswitch {
     bottom: 47px;
@@ -634,6 +636,7 @@
 }
 
 .x42-midifilter{{{cns}}}.x42-midi-velocityscale,
+.x42-midifilter{{{cns}}}.x42-midi-velocitygamma,
 .x42-midifilter{{{cns}}}.x42-midi-strum {
     background-size:420px 360px;
     height:360px;


### PR DESCRIPTION
I added a little "velocity gamma" filter.

This applies a "gamma curve" to all velocities, which is useful to adapt the velocity response to various plugins and keyboards.

The extreme ends of the velocity curve (0 and 127) are left unchanged, but the center (127) is boosted at lower gamma settings, creating a "harder" touch, and at higher settings, the reverse happens, creating a "softer" touch. Setting gamma to 0 will map all input velocities to 127 (x ^ 0 == 1). Gamma = 1 keeps velocities unchanged (x ^ 1 == x).

The formula is pretty much exactly the same as for gamma correction in image processing.