### PR TITLE
Tonalpedal: add sustain mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ midifilter.lv2
 
 LV2 plugins to filter MIDI events.
 
-So far 29 MIDI event filters have been implemented:
+So far 33 MIDI event filters have been implemented:
 
 *   CC2Note -- translate control-commands to note-on/off messages
 *   Channel Filter -- discard messages per channel

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ So far 29 MIDI event filters have been implemented:
 *   Quantize -- live midi event quantization
 *   Velocity Randomizer -- randomly change velocity of note-on events
 *   ScaleCC -- modify the value (data-byte) of a MIDI control change message
-*   Sostenuto -- delay note-off messages, emulate a piano sostenuto pedal
-*   Tonal Pedal -- hold active notes when pressing the sustain pedal
+*   Sostenuto -- delay note-off messages for a set duration
+*   Tonal Pedal -- hold active notes, emulating a piano sustain or sostenuto pedal
 *   Velocity Range -- filter MIDI note events according to velocity
 *   Velocity Gamma -- modify note velocity curve by a gamma exponent
 *   Velocity Scale -- modify note velocity by constant factor and offset

--- a/filters/tonalpedal.c
+++ b/filters/tonalpedal.c
@@ -3,13 +3,17 @@ MFD_FILTER(tonalpedal)
 #ifdef MX_TTF
 
 	mflt:tonalpedal
-	TTF_DEFAULTDEF("MIDI Tonal Pedal", "MIDI Tonal Pedal")
+	TTF_DEFAULTDEF("MIDI Piano Pedal", "MIDI Piano Pedal")
 	, TTF_IPORT( 0, "pedal",  "Pedal CC", 0, 1, 0,
 			lv2:scalePoint [ rdfs:label "CC64" ; rdf:value 0 ] ;
 			lv2:scalePoint [ rdfs:label "CC66" ; rdf:value 1 ] ;
 			lv2:portProperty lv2:integer;  lv2:portProperty lv2:enumeration;)
 	, TTF_IPORTTOGGLE( 1, "forward_cc",   "Forward CC", 0)
-	; rdfs:comment "This filter holds any notes that are currently played when the sustain pedal is pressed for as long as the pedal remains pressed. Releasing the pedal sends Note-Off events. New notes played after presseing the pedal are not affected."
+	, TTF_IPORT( 2, "pedal_style",  "Pedal style", 0, 1, 1,
+			lv2:scalePoint [ rdfs:label "sustain" ; rdf:value 0 ] ;
+			lv2:scalePoint [ rdfs:label "sostenuto" ; rdf:value 1 ] ;
+			lv2:portProperty lv2:integer;  lv2:portProperty lv2:enumeration;)
+	; rdfs:comment "This filter holds any notes played when the pedal is pressed for as long as the pedal remains pressed. Releasing the pedal sends Note-Off events. When pedal style is set to 'sostenuto', new notes played after pressing the pedal are not affected."
 	.
 
 #elif defined MX_CODE
@@ -22,6 +26,7 @@ filter_midi_tonalpedal(MidiFilter* self,
 {
 	const int pedal = RAIL(*self->cfg[0], 0, 1);
 	const int fwdcc = RAIL(*self->cfg[1], 0, 1);
+	const int pedalstyle = RAIL(*self->cfg[2], 0, 1);
 
 	const uint8_t chn = buffer[0] & 0x0f;
 	const uint8_t key = buffer[1] & 0x7f;
@@ -61,9 +66,9 @@ filter_midi_tonalpedal(MidiFilter* self,
 	}
 
 	if (oldstate && !self->memI[chn]) {
-		/* pedal release, send note-off */
+		/* pedal release, send note-off unless manually held */
 		for (int k=0; k < 127; ++k) {
-			if (self->memCS[chn][k]) {
+			if (self->memCS[chn][k] && !self->memCM[chn][k]) {
 				uint8_t buf[3];
 				buf[0] = MIDI_NOTEOFF | chn;
 				buf[1] = k;
@@ -82,33 +87,35 @@ filter_midi_tonalpedal(MidiFilter* self,
 		return;
 	}
 
-	if (mst == MIDI_NOTEON && vel ==0 ) {
+	if (mst == MIDI_NOTEON && vel == 0) {
 		mst = MIDI_NOTEOFF;
 	}
+
+	/* record key state */
+	self->memCM[chn][key] = (mst == MIDI_NOTEON);
 
 	if (self->memI[chn]) {
 		/* pedal is pressed, filter note-off of held notes */
 		if (mst == MIDI_NOTEOFF && self->memCS[chn][key]) {
 			return;
 		}
-		forge_midimessage(self, tme, buffer, size);
-		return;
 	}
 
-	/* pedal is not pressed, collect potential notes */
-	if (mst == MIDI_NOTEON) {
-		self->memCS[chn][key] = 1;
-	} else if (mst == MIDI_NOTEOFF) {
-		self->memCS[chn][key] = 0;
+	/* record sustain state */
+	if ((pedalstyle && !self->memI[chn]) || !pedalstyle) {
+		self->memCS[chn][key] = (mst == MIDI_NOTEON);
 	}
+
 	forge_midimessage(self, tme, buffer, size);
+
 }
 
 static void filter_init_tonalpedal(MidiFilter* self) {
 	for (uint32_t c = 16; c < 16; ++c) {
 		self->memI[c] = 0; // per channel pedal (CC64)
 		for (int k=0; k < 127; ++k) {
-			self->memCS[c][k] = 0;
+			self->memCS[c][k] = 0; // notes sustained by pedal
+			self->memCM[c][k] = 0; // notes with key pressed
 		}
 	}
 }

--- a/filters/tonalpedal.c
+++ b/filters/tonalpedal.c
@@ -3,7 +3,7 @@ MFD_FILTER(tonalpedal)
 #ifdef MX_TTF
 
 	mflt:tonalpedal
-	TTF_DEFAULTDEF("MIDI Piano Pedal", "MIDI Piano Pedal")
+	TTF_DEFAULTDEF("MIDI Sustain Pedal", "MIDI Sustain Pedal")
 	, TTF_IPORT( 0, "pedal",  "Pedal CC", 0, 1, 0,
 			lv2:scalePoint [ rdfs:label "CC64" ; rdf:value 0 ] ;
 			lv2:scalePoint [ rdfs:label "CC66" ; rdf:value 1 ] ;


### PR DESCRIPTION
Now just adding the pedalstyle option to Tonal Pedal. The default is 1 (sostenuto) to match the previous behaviour.

One change is that the pedal release does not release notes which are currently manually pressed. This is for both sustain and sostenuto styles to match the behaviour of physical instruments. I'd argue that the previous behaviour was incorrect, therefore I haven't made this optional.